### PR TITLE
Resolve eslint path relative to current buffer path

### DIFF
--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -1,5 +1,5 @@
 let s:lcd = getcwd()
-exec "lcd" expand('%:p:h')
+silent! exec "lcd" expand('%:p:h')
 let s:eslint_path = system('PATH=$(npm bin):$PATH && which eslint')
 exec "lcd" s:lcd
 let b:syntastic_javascript_eslint_exec = substitute(s:eslint_path, '^\n*\s*\(.\{-}\)\n*\s*$', '\1', '')

--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -1,2 +1,5 @@
+let s:lcd = getcwd()
+exec "lcd" expand('%:p:h')
 let s:eslint_path = system('PATH=$(npm bin):$PATH && which eslint')
+exec "lcd" s:lcd
 let b:syntastic_javascript_eslint_exec = substitute(s:eslint_path, '^\n*\s*\(.\{-}\)\n*\s*$', '\1', '')


### PR DESCRIPTION
The previous behavior was to use resolve the eslint binary relative to
the current working directory of vim. One vim session may be used to
edit files across many different projects though, which means that
different eslint installations may exist for the different buffers
currently open.