### PR TITLE
use g:syntastic_javascript_eslint_exec

### DIFF
--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -2,4 +2,4 @@ let s:lcd = getcwd()
 silent! exec "lcd" expand('%:p:h')
 let s:eslint_path = system('PATH=$(npm bin):$PATH && which eslint')
 exec "lcd" s:lcd
-let b:syntastic_javascript_eslint_exec = substitute(s:eslint_path, '^\n*\s*\(.\{-}\)\n*\s*$', '\1', '')
+let g:syntastic_javascript_eslint_exec = substitute(s:eslint_path, '^\n*\s*\(.\{-}\)\n*\s*$', '\1', '')


### PR DESCRIPTION
b:syntastic_javascript_eslint_exec not work in syntastic.

see https://github.com/scrooloose/syntastic/blob/master/doc/syntastic-checkers.txt#L3126