### PR TITLE
performance: cache the syntastic_eslint_path

### DIFF
--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -1,5 +1,8 @@
-let s:lcd = fnameescape(getcwd())
-silent! exec "lcd" expand('%:p:h')
-let s:eslint_path = system('PATH=$(npm bin):$PATH && which eslint')
-exec "lcd" s:lcd
-let b:syntastic_javascript_eslint_exec = substitute(s:eslint_path, '^\n*\s*\(.\{-}\)\n*\s*$', '\1', '')
+if (!exists('g:syntastic_eslint_path'))
+  let s:lcd = fnameescape(getcwd())
+  silent! exec "lcd" expand('%:p:h')
+  let s:eslint_path = system('PATH=$(npm bin):$PATH && which eslint')
+  exec "lcd" s:lcd
+  let g:syntastic_eslint_path = substitute(s:eslint_path, '^\n*\s*\(.\{-}\)\n*\s*$', '\1', '')
+endif
+let b:syntastic_javascript_eslint_exec = g:syntastic_eslint_path


### PR DESCRIPTION
This change will make sure that you don't get hit with the performance penalty of calling npm and finding the right eslint version more than once per session.
