### PR TITLE
Only find local eslint binary once, and then eslint exec were updated

### DIFF
--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -1,5 +1,8 @@
-let s:lcd = fnameescape(getcwd())
-silent! exec "lcd" expand('%:p:h')
-let s:eslint_path = system('PATH=$(npm bin):$PATH && which eslint')
-exec "lcd" s:lcd
-let b:syntastic_javascript_eslint_exec = substitute(s:eslint_path, '^\n*\s*\(.\{-}\)\n*\s*$', '\1', '')
+if !exists("g:localEslintDetected")
+    let s:lcd = fnameescape(getcwd())
+    silent! exec "lcd" expand('%:p:h')
+    let s:eslint_path = system('PATH=$(npm bin):$PATH && which eslint')
+    exec "lcd" s:lcd
+    let g:syntastic_javascript_eslint_exec = substitute(s:eslint_path, '^\n*\s*\(.\{-}\)\n*\s*$', '\1', '')
+    let g:localEslintDetected=1
+endif


### PR DESCRIPTION
There is no need to do the same job of finding eslint exec over and over again each time trying to open a js file