### PR TITLE
Add support for "npm run lint"

### DIFF
--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -11,6 +11,20 @@ fun! s:GetNodeModulesAbsPath ()
   return path is '' ? '' : fnamemodify(path, ':p')
 endfun
 
+" check if the app package.json has a lint script
+function! s:HasNPMLintScript (node_modules)
+    let packagejson_path = substitute(a:node_modules, "node_modules/", "package.json", "")
+
+    " check if package.json is available
+    if !filereadable(packagejson_path)
+      return 0
+    endif
+
+    " pretty simple match checking for lint task on package.json
+    let packagejson = join(readfile(packagejson_path), "\n")
+    return packagejson =~ '"lint": "' ? 1 : 0
+endfunction
+
 " return full path of local eslint executable
 "  or an empty string if no executable found
 fun! s:GetEslintExec (node_modules)
@@ -27,8 +41,13 @@ endfun
 
 fun! s:main ()
   let node_modules = s:GetNodeModulesAbsPath()
-  let eslint_exec = s:GetEslintExec(node_modules)
-  call s:LetEslintExec(eslint_exec)
+
+  if s:HasNPMLintScript(node_modules)
+    let g:syntastic_javascript_eslint_exe = 'npm run lint --'
+  else
+    let eslint_exec = s:GetEslintExec(node_modules)
+    call s:LetEslintExec(eslint_exec)
+  endif
 endfun
 
 call s:main()


### PR DESCRIPTION
This change add support to use use "npm run lint" instead of just
"eslint" if that task is available on package.json.