### PR TITLE
Added the option of using another executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ Using [vim plugged](https://github.com/junegunn/vim-plug) you just need to add:
 Plug 'mtscout6/syntastic-local-eslint.vim'
 ```
 
+Configuration
+-------------
+
+If you want to use a different executable, e.g. `eslint_d`, then set the
+`g:syntastic_local_eslint_exec` variable.
+
+e.g. ` let g:syntastic_javascript_eslint_exec = 'eslint_d'` in your `vimrc`.
+
 Inspired By
 -----------
 

--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -13,8 +13,9 @@ endfun
 
 " return full path of local eslint executable
 "  or an empty string if no executable found
-fun! s:GetEslintExec (node_modules)
-  let eslint_guess = a:node_modules is '' ? '' : a:node_modules . '.bin/eslint'
+fun! s:GetEslintExec (node_modules, exec)
+  let bin = a:exec is '' ? 'eslint' : a:exec
+  let eslint_guess = a:node_modules is '' ? '' : a:node_modules . '.bin/' . bin
   return exepath(eslint_guess)
 endfun
 
@@ -27,7 +28,8 @@ endfun
 
 fun! s:main ()
   let node_modules = s:GetNodeModulesAbsPath()
-  let eslint_exec = s:GetEslintExec(node_modules)
+  let eslint_bin = exists("g:syntastic_local_eslint_exec") ? g:syntastic_local_eslint_exec : 'eslint'
+  let eslint_exec = s:GetEslintExec(node_modules, eslint_bin)
   call s:LetEslintExec(eslint_exec)
 endfun
 


### PR DESCRIPTION
I like to use eslint_d when I can, and I'd prefer to use it locally when it's available. I figured that having learned just enough vimscript to add the option, I might as well offer it back. :)